### PR TITLE
mitmf-git PKGBUILD cleanup

### DIFF
--- a/packages/mitmf-git/PKGBUILD
+++ b/packages/mitmf-git/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: ArchAssault <team archassault org>
 pkgname=mitmf-git
-pkgver=20141216.r180
-pkgrel=1
+pkgver=20141227.r184
+pkgrel=3
 groups=('archassault' 'archassault-proxy' 'archassault-spoof')
 pkgdesc="A Framework for Man-In-The-Middle attacks written in Python."
 arch=('any')
@@ -40,7 +40,7 @@ package() {
   cp -a libs/* "$pkgdir/usr/share/mitmf/libs/"
   grep -iRl 'python' "$pkgdir/usr/share/mitmf/libs/bdfactory" | xargs sed -i 's|#!.*/usr/bin/python|#!/usr/bin/python2|;s|#!.*/usr/bin/env python$|#!/usr/bin/env python2|'
   cp -a  config/responder/* "$pkgdir/usr/share/mitmf/config/responder/"
-  for i in `find config/ -type f`; do install -Dm644 $i "$pkgdir/usr/share/mitmf/config/$i" ;done
+  for i in `find config/ -type f`; do install -Dm644 $i "$pkgdir/usr/share/mitmf/$i" ;done
   #for i in `find libs/ -type f -iname "*.py"`; do install -Dm644 $i "$pkgdir/usr/share/mitmf/libs/$i" ;done
   install -Dm644 plugins/* "$pkgdir/usr/share/mitmf/plugins/"
   install -Dm644 README.md "$pkgdir/usr/share/mitmf/"

--- a/packages/mitmf-git/PKGBUILD
+++ b/packages/mitmf-git/PKGBUILD
@@ -34,7 +34,7 @@ package() {
   install -dm744 "$pkgdir/usr/share/mitmf/"
   install -dm744 "$pkgdir/usr/bin/"
   install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
-  cp -dpr --no-preserve=ownership * "$pkgdir/usr/share/mitmf/"
+  cp -a --no-preserve=ownership * "$pkgdir/usr/share/mitmf/"
 
   cd ${pkgdir}
   find ./ -type d -exec chmod 755 {} \+

--- a/packages/mitmf-git/PKGBUILD
+++ b/packages/mitmf-git/PKGBUILD
@@ -30,31 +30,20 @@ prepare(){
 
 package() {
   cd "${pkgname}"
-  install -dm755 "$pkgdir/usr/bin"
-  install -dm755 "$pkgdir/usr/share/mitmf/libs"
-  install -dm755 "$pkgdir/usr/share/mitmf/config"
-  install -dm755 "$pkgdir/usr/share/mitmf/config/responder"
-  install -dm755 "$pkgdir/usr/share/mitmf/config/app_cache_poison_templates/"
-  install -dm755 "$pkgdir/usr/share/mitmf/plugins"
-  install -dm755 "$pkgdir/usr/share/mitmf/logs"
-  cp -a libs/* "$pkgdir/usr/share/mitmf/libs/"
-  grep -iRl 'python' "$pkgdir/usr/share/mitmf/libs/bdfactory" | xargs sed -i 's|#!.*/usr/bin/python|#!/usr/bin/python2|;s|#!.*/usr/bin/env python$|#!/usr/bin/env python2|'
-  cp -a  config/responder/* "$pkgdir/usr/share/mitmf/config/responder/"
-  for i in `find config/ -type f`; do install -Dm644 $i "$pkgdir/usr/share/mitmf/$i" ;done
-  #for i in `find libs/ -type f -iname "*.py"`; do install -Dm644 $i "$pkgdir/usr/share/mitmf/libs/$i" ;done
-  install -Dm644 plugins/* "$pkgdir/usr/share/mitmf/plugins/"
-  install -Dm644 README.md "$pkgdir/usr/share/mitmf/"
-  install -Dm644 config/app_cache_poison_templates/* "$pkgdir/usr/share/mitmf/config/app_cache_poison_templates/"
-  install -Dm755 *.py "$pkgdir/usr/share/mitmf/"
-  install -Dm644 *.ico "$pkgdir/usr/share/mitmf/"
-  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 
-cat > "$pkgdir/usr/bin/mitmf" <<EOF
+  install -dm744 "$pkgdir/usr/share/mitmf/"
+  install -dm744 "$pkgdir/usr/bin/"
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  cp -dpr --no-preserve=ownership * "$pkgdir/usr/share/mitmf/"
+
+  cd ${pkgdir}
+  find ./ -type d -exec chmod 755 {} \+
+  find ./ -type f -exec chmod 644 {} \+
+  
+cat > "${pkgdir}/usr/bin/mitmf" <<EOF
 #!/bin/sh
 cd /usr/share/mitmf
 python2 mitmf.py "\$@"
 EOF
-
-chmod +x "$pkgdir/usr/bin/mitmf"
-
+  chmod +x "$pkgdir/usr/bin/mitmf"
 }


### PR DESCRIPTION
Housekeeping on mitmf-git PKGBUILD. python2-user-agents and python2-pillow left out of dep. array to avoid upstream conflicts.