### PR TITLE
First package for repo: sparta-git

### DIFF
--- a/packages/sparta-git/PKGBUILD
+++ b/packages/sparta-git/PKGBUILD
@@ -9,7 +9,7 @@ arch=('any')
 url="https://github.com/SECFORCE/sparta"
 groups=('archassault' 'archassault-scanners')
 license=('GPL3')
-depends=('python2' 'nmap' 'hydra' 'cutycapt') 
+depends=('python2') 
 makedepends=('git')
 provides=('sparta')
 replaces=('sparta')
@@ -30,15 +30,11 @@ prepare(){
 package() {
   cd "${pkgname}"
 
-  install -dm744 "$pkgdir/usr/share/sparta/"
-  install -dm744 "$pkgdir/usr/bin/"
+  install -dm755 "$pkgdir/usr/share/sparta/"
+  install -dm755 "$pkgdir/usr/bin/"
   install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
   cp -a --no-preserve=ownership * "$pkgdir/usr/share/sparta/"
 
-  cd ${pkgdir}
-  find ./ -type d -exec chmod 755 {} \+
-  find ./ -type f -exec chmod 644 {} \+
-  
 cat > "${pkgdir}/usr/bin/sparta" <<EOF
 #!/bin/sh
 cd /usr/share/sparta

--- a/packages/sparta-git/PKGBUILD
+++ b/packages/sparta-git/PKGBUILD
@@ -1,0 +1,48 @@
+# Maintainer: ArchAssault <team archassault org>
+# Contributor: Cthulu201 <cthulu201@archassault.org>
+
+pkgname=sparta-git
+pkgver=20141218.r10
+pkgrel=1
+pkgdesc="A GUI application which simplifies network infrastructure penetration testing by aiding the penetration tester in the scanning and enumeration phase"
+arch=('any')
+url="https://github.com/SECFORCE/sparta"
+groups=('archassault' 'archassault-scanners')
+license=('GPL3')
+depends=('python2' 'nmap' 'hydra' 'cutycapt') 
+makedepends=('git')
+provides=('sparta')
+replaces=('sparta')
+conflicts=('sparta')
+options=('emptydirs')
+source=("${pkgname}::git+https://github.com/SECFORCE/sparta.git")
+sha512sums=('SKIP')
+
+pkgver() {
+  cd "${pkgname}"
+  printf "%s.r%s" "$(git show -s --format=%ci master | sed 's/\ .*//g;s/-//g')" "$(git rev-list --count HEAD)"
+}
+
+prepare(){
+  grep -iRl 'python' "$srcdir/${pkgname}" | xargs sed -i 's|#!.*/usr/bin/python|#!/usr/bin/python2|;s|#!.*/usr/bin/env python$|#!/usr/bin/env python2|'
+}
+
+package() {
+  cd "${pkgname}"
+
+  install -dm744 "$pkgdir/usr/share/sparta/"
+  install -dm744 "$pkgdir/usr/bin/"
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  cp -a --no-preserve=ownership * "$pkgdir/usr/share/sparta/"
+
+  cd ${pkgdir}
+  find ./ -type d -exec chmod 755 {} \+
+  find ./ -type f -exec chmod 644 {} \+
+  
+cat > "${pkgdir}/usr/bin/sparta" <<EOF
+#!/bin/sh
+cd /usr/share/sparta
+python2 sparta.py "\$@"
+EOF
+  chmod +x "$pkgdir/usr/bin/sparta"
+}


### PR DESCRIPTION
My first package:
SPARTA is a python GUI application which simplifies network infrastructure penetration testing by aiding the penetration tester in the scanning and enumeration phase. It allows the tester to save time by having point-and-click access to his toolkit and by displaying all tool output in a convenient way. If little time is spent setting up commands and tools, more time can be spent focusing on analysing results.